### PR TITLE
unfixed footer, added name of store to not found page

### DIFF
--- a/src/components/Capacity/Capacity.module.scss
+++ b/src/components/Capacity/Capacity.module.scss
@@ -23,7 +23,13 @@
   }
 
   &__link {
-   padding: 7px 8px 4px;
+   width: 60px;
+   height: 32px;
+
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   
    color: $primaryColor;
 
    @include bodyText;

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -2,10 +2,6 @@
 @import '../../utils/_mixins.scss';
 
 .footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
   padding: 32px 0;
 
   background-color: $backgroundColor;

--- a/src/pages/NotFoundPages/NotFoundPage.module.scss
+++ b/src/pages/NotFoundPages/NotFoundPage.module.scss
@@ -2,7 +2,6 @@
 @import '../../utils/vars';
 
 .not-found-page {
-  position: fixed;
   width: 100%;
   height: 100%;
 
@@ -14,7 +13,7 @@
     color: #fff;
     font-size: 80px;
 
-    margin: 30px 0;
+    padding: 30px 0;
 
     @include onMobile {
       font-size: 70px;

--- a/src/pages/NotFoundPages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPages/NotFoundPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import style from './NotFoundPage.module.scss';
 import astronaut from '../../images/astronaut.png';
+import { Link } from 'react-router-dom';
 
 export const NotFoundPage: React.FC = () => (
   <div className={style['not-found-page']}>
@@ -9,12 +10,12 @@ export const NotFoundPage: React.FC = () => (
     <h3 className={style['not-found-page__text']}>
       LOST IN
       <span className={style['not-found-page__text--crossedOut']}> SPACE </span>
-      App-Name? Hmm, looks like this page is not found.
+      Nice Gadgets? Hmm, looks like this page is not found.
     </h3>
 
-    <a href="#">
+    <Link to={'/home'}>
       <button className={style['not-found-page__link']}>Go Home</button>
-    </a>
+    </Link>
 
     <img
       className={style['not-found-page__img']}


### PR DESCRIPTION
small fixes with footer and notFoundPage, added link to homepage on notFoundPage
<img width="1536" alt="Знімок екрана 2023-08-09 о 12 06 55" src="https://github.com/fe-apr23-ChatGPT-approved/product_catalog_frontend/assets/113480768/1c8c975b-5c81-403a-989a-199388a47cdc">
